### PR TITLE
Separator, before and after text

### DIFF
--- a/README.org
+++ b/README.org
@@ -15,6 +15,23 @@ Translation: I ate AEU KAR ROT TP-PL
 
 and so on.
 
+You can specify the stroke separator and text to go before and after with the syntax =retro_stroke:separator,before,after.
+
+By default the separator is a space and the before and after text is empty.
+
+If you define a stroke as =retro_stroke:/, `,`
+
+#+begin_example
+Strokes:     EU AEUT AEU KAR ROT TP-PL STR*L
+Translation: I ate a carrot `TP-PL`
+
+Strokes:     EU AEUT AEU KAR ROT TP-PL STR*L STR*L
+Translation: I ate a `KAR/ROT/TP-PL`
+
+Strokes:     EU AEUT AEU KAR ROT TP-PL STR*L STR*L STR*L
+Translation: I ate `AEU/KAR/ROT/TP-PL`
+#+end_example
+
 You can install this plugin from the command-line with:
 
 #+begin_example

--- a/plover_retro_stroke/__init__.py
+++ b/plover_retro_stroke/__init__.py
@@ -8,6 +8,11 @@ def flatten(x: List[List]) -> List:
     return list(itertools.chain.from_iterable(x))
 
 def retro_stroke(translator: Translator, stroke: Stroke, cmdline: str):
+    args = cmdline.split(",")
+    separator = args[0] or " "
+    before = args[1] or ""
+    after = args[2] or ""
+
     all_translations = translator.get_state().translations
     affected_translation_cnt = len(list(
         itertools.takewhile(
@@ -17,11 +22,11 @@ def retro_stroke(translator: Translator, stroke: Stroke, cmdline: str):
     ))
     affected_translations = all_translations[-(affected_translation_cnt + 1):]
     affected_strokes = flatten([x.strokes for x in affected_translations])
-    result = ' '.join([x.rtfcre for x in reversed(list(itertools.dropwhile(
+    result = separator.join([x.rtfcre for x in reversed(list(itertools.dropwhile(
         lambda x: x == stroke,
         reversed(affected_strokes)
     )))])
-    my_trans = Translation(affected_strokes + [stroke], result)
+    my_trans = Translation(affected_strokes + [stroke], before + result + after)
     my_trans.replaced = affected_translations
     translator.translate_translation(my_trans)
 

--- a/plover_retro_stroke/__init__.py
+++ b/plover_retro_stroke/__init__.py
@@ -9,9 +9,9 @@ def flatten(x: List[List]) -> List:
 
 def retro_stroke(translator: Translator, stroke: Stroke, cmdline: str):
     args = cmdline.split(",")
-    separator = args[0] or " "
-    before = args[1] or ""
-    after = args[2] or ""
+    separator = args[0] if len(args) > 0 else " "
+    before = args[1] if len(args) > 1 else ""
+    after = args[2] if len(args) > 2 else ""
 
     all_translations = translator.get_state().translations
     affected_translation_cnt = len(list(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [metadata]
 name = plover_retro_stroke
 keywords = plover
+description = Converts the last X translations to their stroke form
+long_description = file: README.org
+long_description_content_type = text/org
 
 [options]
 zip_safe = True


### PR DESCRIPTION
heya!

this plugin has been really useful to me, so i've made a few changes that helped me:

 - configured the readme to show up in the plover plugins manager
 - added some arguments for the separator, before and after text (e.g. for formatting strokes for markdown. i've added this example to the readme)

i made this pull request in case you were interested. feel free to ignore!